### PR TITLE
Decline earlier than asked

### DIFF
--- a/src/messageservice.js
+++ b/src/messageservice.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const AttendanceEnum = require('./participant').AttendanceEnum;
-const States = require('./states').States;
 
 class MessageService {
   constructor(messageFunction, model, store) {
@@ -166,14 +165,9 @@ If you won't attend, please respond \`no\`.`));
 
   status(userName) {
     const state = this.store.getState();
-    if (state.type === States.SEARCH_INITIATED || state.type === States.AWAITING_MEETING) {
-      this.sendMessage(userName, `Responsible: ${this.model.getResponsible().link} (${state.foundResponsible ? 'confirmed' : 'not confirmed'})
+    this.sendMessage(userName, `Responsible: ${this.model.getResponsible().link} (${state.foundResponsible ? 'confirmed' : 'not confirmed'})
 
 ${this._generateParticipationList()}`);
-    }
-    else {
-      this.sendMessage(userName, 'Participation count has not yet begun.');
-    }
   }
 
   unknownCommand(userName) {

--- a/src/messageservice.js
+++ b/src/messageservice.js
@@ -41,7 +41,7 @@ class MessageService {
   }
 
   attending(userName) {
-    this.sendMessage(userName, 'Thank you for your response. I have noted that you\'ll *be attending* tomorrow.');
+    this.sendMessage(userName, 'Thank you for your response. I have noted that you\'ll *be attending* the next meeting.');
   }
 
   botActivated(botName) {
@@ -102,7 +102,7 @@ Current list: ${this.model.getParticipantLinks().join(', ')}`);
   }
 
   notAttending(userName) {
-    this.sendMessage(userName, 'Thank you for your response. I have noted that you will *not be attending* tomorrow.');
+    this.sendMessage(userName, 'Thank you for your response. I have noted that you will *not be attending* the next meeting.');
   }
 
   notifyNewResponsible(oldResponsible) {

--- a/src/messageservice.js
+++ b/src/messageservice.js
@@ -139,7 +139,7 @@ ${this._generateParticipationList()}`
 
   queryForAttendance() {
     this.model.participants
-        .filter((participant) => !participant.responsible && participant.isSlackUser())
+        .filter((participant) => !participant.responsible && participant.isSlackUser() && participant.attending === AttendanceEnum.UNKNOWN)
         .forEach((participant) => this.sendMessage(participant.username,
             `To help ${this.model.getResponsible().link} buy the correct number of roundpieces, please respond to this message before 12.00 today.
 Please respond \`yes\` if you're attending the roundpieces meeting tomorrow.

--- a/src/roundpiecesbot.js
+++ b/src/roundpiecesbot.js
@@ -325,7 +325,7 @@ class RoundpiecesBot extends Bot {
   }
 
   _canChangeAttendanceStatus(participant) {
-    if (this.state.type !== States.SEARCH_INITIATED) {
+    if (this.state.type !== States.SEARCH_INITIATED && this.state.type !== States.IDLE) {
       this.messageService.wrongTime(participant.username);
       return false;
     }

--- a/src/states.js
+++ b/src/states.js
@@ -84,9 +84,8 @@ function reset(state) {
     case States.SEARCH_INITIATED:
     case States.AWAITING_MEETING:
     case States.NO_ATTENDANCE:
-      return Object.assign({}, state, {type: States.RESETTING});
     case States.SKIPPED:
-      return Object.assign({}, state, {type: States.IDLE});
+      return Object.assign({}, state, {type: States.RESETTING});
     default:
       return state;
   }


### PR DESCRIPTION
Adds the ability to mark attendance for next meeting before being asked.
Adds the ability to reject early for the responsible.
Does not make it possible to accept early as the responsible. Accepting early would bring too much worry if the responsible forgets during the week or suddenly becomes unable to attend. It's safer to wait for an acceptance until the day before the meeting.

Fixes #1.
